### PR TITLE
Create artifact on master merge

### DIFF
--- a/.travis.settings.xml
+++ b/.travis.settings.xml
@@ -11,13 +11,24 @@
 
             <repositories>
                 <repository>
-                    <id>release-repo</id>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                    <id>central</id>
                     <name>libs-release</name>
                     <url>http://artifactory-sdc.onsdigital.uk/artifactory/libs-release-local</url>
                 </repository>
                 <repository>
-                    <id>snapshot-repo</id>
+                    <id>snapshots</id>
                     <url>http://artifactory-sdc.onsdigital.uk/artifactory/libs-snapshot-local/</url>
+                </repository>
+                <repository>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                    <id>maven-central</id>
+                    <name>Central Repository</name>
+                    <url>https://repo.maven.apache.org/maven2</url>
                 </repository>
             </repositories>
         </profile>
@@ -26,4 +37,17 @@
     <activeProfiles>
         <activeProfile>artifactory</activeProfile>
     </activeProfiles>
+
+    <servers>
+        <server>
+            <username>travis</username>
+            <password>${env.ARTIFACTORY_PASSWORD}</password>
+            <id>central</id>
+        </server>
+        <server>
+            <username>travis</username>
+            <password>${env.ARTIFACTORY_PASSWORD}</password>
+            <id>snapshots</id>
+        </server>
+    </servers>
 </settings>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,23 @@
 language: java
 jdk: openjdk8
 
-before_install: cp .travis.settings.xml $HOME/.m2/settings.xml
+before_install:
+  # Checkout master branch not commit on master builds
+  - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+    git checkout $TRAVIS_BRANCH;
+    fi
+  - cp .travis.settings.xml $HOME/.m2/settings.xml
+  - curl ifconfig.co|xargs echo "Travis IP address is ";
+
+script:
+  - mvn test -B
+  # Only release on master builds
+  - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+    git config --global set user.email "travis@travis-ci.org";
+    git config --global set user.name "Travis CI";
+    mvn -B -Dusername=$GITHUB_API_KEY release:prepare;
+    mvn -B release:perform;
+    fi
 
 notifications:
   slack:

--- a/pom.xml
+++ b/pom.xml
@@ -1,8 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>uk.gov.ons.ctp.product</groupId>
   <artifactId>surveysvc-api</artifactId>
   <version>10.49.1-SNAPSHOT</version>
   <packaging>jar</packaging>
@@ -19,7 +17,7 @@
   <parent>
     <groupId>uk.gov.ons.ctp.product</groupId>
     <artifactId>rm-common-config</artifactId>
-    <version>10.49.1</version>
+    <version>10.49.6</version>
   </parent>
 
   <dependencies>
@@ -30,9 +28,9 @@
   </dependencies>
 
   <scm>
-      <connection>scm:git:git@github.com:ONSdigital/rm-collection-exercise-service.git</connection>
-      <developerConnection>scm:git:git@github.com:ONSdigital/rm-collection-exercise-service.git</developerConnection>
-      <url>git@github.com:ONSdigital/rm-collection-exercise-service.git</url>
+    <url>https://github.com/ONSdigital/rm-surveysvc-api</url>
+    <connection>scm:git:https://github.com/ONSdigital/rm-surveysvc-api</connection>
+    <developerConnection>scm:git:https://github.com/ONSdigital/rm-surveysvc-api</developerConnection>
   </scm>
 
   <build>


### PR DESCRIPTION
We want to create and publish release artifacts on every merge to
master. The repository is unlikely to change often so wont happen often
either. When the artifact has been deployed consuming projects will need
to increase the version.

https://trello.com/c/jnq0ugGL/14-create-release-artifacts-on-merge-back-to-master-for-api-and-common-libraries

Depends on https://github.com/ONSdigital/rm-common-config/pull/1

# Testing
1. Check or set the travis build has the environmental variables `GITHUB_API_KEY`, `ARTIFACTORY_PASSWORD` are set correctly
1. Create new branch from `14-create-release-artifacts`
1. Change references in `.travis.yml` to `master` to your new branch name
1. `git push` branch up
1. Check build is successful
1. Check artifactory for new artifact
1. Check github for new tag

Note. You should tidy up after yourself by
1. Deleting the new artifact in artifactory
1. Deletign the new tag in github