### PR TITLE
Added SurveyType to SurveyDTO

### DIFF
--- a/src/main/java/uk/gov/ons/response/survey/representation/SurveyDTO.java
+++ b/src/main/java/uk/gov/ons/response/survey/representation/SurveyDTO.java
@@ -11,10 +11,17 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 public class SurveyDTO {
+
+  public enum SurveyType {
+    Business,
+    Social,
+    Census
+  }
   private String id;
   private String shortName;
   private String longName;
   private String surveyRef;
   private String legalBasis;
   private String legalBasisRef;
+  private SurveyType surveyType;
 }

--- a/src/main/java/uk/gov/ons/response/survey/representation/SurveyDTO.java
+++ b/src/main/java/uk/gov/ons/response/survey/representation/SurveyDTO.java
@@ -12,6 +12,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 public class SurveyDTO {
 
+  /**
+   * This enum denotes the type of the survey.  Business and Social are currently actively used throughout.
+   * Census is supported as a survey type in the loosest sense in some areas of the system but not in others.
+   * Hence it may be deprecated when the real census comes around.
+   */
   public enum SurveyType {
     Business,
     Social,


### PR DESCRIPTION
# Motivation and Context
The SurveyDTO class has been modified to include a survey type, detailing which area a survey pertains to.

# What has changed
Survey type was added as an enum to define a survey as either a business, social or census type.
