### PR TITLE
Added spurious comment to force another maven release in travis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!-- Spurious comment to force another maven release in travis -->
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>surveysvc-api</artifactId>


### PR DESCRIPTION
# Motivation and Context
The maven release of the merge of the previous PR timed out and failed to deploy the release artifact to artifactory.  A new PR needs to be raised to force another maven release

# What has changed
A spurious comment has been added to pom.xml

# How to test?
- Run 'mvn clean install'
- Ensure build does not fail with a syntax error

