### PR TITLE
added styler to codebase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - curl ifconfig.co|xargs echo "Travis IP address is ";
 
 script:
-  - "mvn cobertura:cobertura"
+  - "mvn fmt:check verify cobertura:cobertura"
   - mvn test -B
   # Only release on master builds
   - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ This is the Survey Service public API model project.
 
 It simply contains the representation objects sent/returned to/from the Survey Service REST endpoints.
 
+# Code Styler
+To use the code styler please goto this url (https://github.com/google/google-java-format) and follow the Intellij instructions or Eclipse depending on what you use
+
 # Creating a release artifact
 There are no additional steps required to generate a release artifact. Travis takes care of all of this.
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>uk.gov.ons.ctp.product</groupId>
     <artifactId>rm-common-config</artifactId>
-    <version>10.49.6</version>
+    <version>10.49.11</version>
   </parent>
 
   <dependencies>
@@ -46,6 +46,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>com.coveo</groupId>
+        <artifactId>fmt-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/uk/gov/ons/response/survey/representation/SurveyClassifierDTO.java
+++ b/src/main/java/uk/gov/ons/response/survey/representation/SurveyClassifierDTO.java
@@ -4,15 +4,11 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/**
- * SurveyClassifier API representation
- *
- */
+/** SurveyClassifier API representation */
 @Data
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 public class SurveyClassifierDTO {
 
   private String id;
   private String name;
-
 }

--- a/src/main/java/uk/gov/ons/response/survey/representation/SurveyClassifierTypeDTO.java
+++ b/src/main/java/uk/gov/ons/response/survey/representation/SurveyClassifierTypeDTO.java
@@ -1,15 +1,11 @@
 package uk.gov.ons.response.survey.representation;
 
 import java.util.List;
-
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/**
- * SurveyClassifierType API representation
- *
- */
+/** SurveyClassifierType API representation */
 @Data
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 public class SurveyClassifierTypeDTO {
@@ -17,5 +13,4 @@ public class SurveyClassifierTypeDTO {
   private String id;
   private String name;
   private List<String> classifierTypes;
-
 }

--- a/src/main/java/uk/gov/ons/response/survey/representation/SurveyDTO.java
+++ b/src/main/java/uk/gov/ons/response/survey/representation/SurveyDTO.java
@@ -4,24 +4,22 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/**
- * Survey API representation
- *
- */
+/** Survey API representation */
 @Data
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 public class SurveyDTO {
 
   /**
-   * This enum denotes the type of the survey.  Business and Social are currently actively used throughout.
-   * Census is supported as a survey type in the loosest sense in some areas of the system but not in others.
-   * Hence it may be deprecated when the real census comes around.
+   * This enum denotes the type of the survey. Business and Social are currently actively used
+   * throughout. Census is supported as a survey type in the loosest sense in some areas of the
+   * system but not in others. Hence it may be deprecated when the real census comes around.
    */
   public enum SurveyType {
     Business,
     Social,
     Census
   }
+
   private String id;
   private String shortName;
   private String longName;


### PR DESCRIPTION
# Motivation and Context
Adding maven plugin to format the java code automatically on builds. The
style of the formatter is opinionated favouring googles formatting. The
benefit of this is it allows us to easily plugin in googles check style
file. The checkstyle.xml has been made more lenient to ignore things
like missing javadoc and abbreviations.

# What has changed
Inherit new checkstyle configuration from parent pom
Inerit formatting from parent pom
Travis to fail on invalid style or checkstyle

# How to test?
1. Checkout branch
1. Mess up format
1. Run mvn install
1. Check format is fixed

# Links
Formatter plugin: https://github.com/google/coveo/fmt-maven-plugin
Checkstyle plugin: https://github.com/google/checkstyle/checkstyle
Intellij formatter: https://github.com/google/google/google-java-format#intellij
Eclipse formatter: https://github.com/google/google-java-format#eclipse
